### PR TITLE
fix(telegram): back off stream updates on rate limits

### DIFF
--- a/internal/channel/channel_test.go
+++ b/internal/channel/channel_test.go
@@ -1301,6 +1301,47 @@ func TestTelegramChannel_SendStream_FinalSendFailureKeepsIntermediateMessages(t 
 	}
 }
 
+func TestTelegramRetryAfter(t *testing.T) {
+	delay, ok := telegramRetryAfter(errors.New(`telego: editMessageText: api: 429 "Too Many Requests: retry after 717", migrate to chat ID: 0, retry after: 717`))
+	if !ok {
+		t.Fatal("expected retry after to be detected")
+	}
+	if delay != 717*time.Second {
+		t.Fatalf("delay = %v, want %v", delay, 717*time.Second)
+	}
+	if _, ok := telegramRetryAfter(errors.New("plain error")); ok {
+		t.Fatal("unexpected retry after for plain error")
+	}
+}
+
+func TestTelegramChannel_SendStream_FinalSend429RetriesOnce(t *testing.T) {
+	ch, caller := newTestChannel(t, config.TelegramConfig{Streaming: true, Feedback: "debug"})
+	caller.methodErrSeq = map[string][]error{
+		"sendMessage": {nil, errors.New(`telego: sendMessage: api: 429 "Too Many Requests: retry after 0", migrate to chat ID: 0, retry after: 0`), nil},
+	}
+
+	events := make(chan api.StreamEvent, 10)
+	iter := 0
+	events <- api.StreamEvent{Type: api.EventIterationStart, Iteration: &iter}
+	events <- api.StreamEvent{Type: api.EventToolExecutionStart, ToolUseID: "t1", Name: "Read", Iteration: &iter}
+	events <- api.StreamEvent{Type: api.EventContentBlockDelta, Delta: &api.Delta{Type: "text_delta", Text: "partial result"}}
+	close(events)
+
+	if err := ch.SendStream(context.Background(), "123", nil, events); err != nil {
+		t.Fatalf("SendStream error: %v", err)
+	}
+
+	var sendCount int
+	for _, c := range caller.calls {
+		if strings.HasSuffix(c.URL, "/sendMessage") {
+			sendCount++
+		}
+	}
+	if sendCount < 3 {
+		t.Fatalf("expected retry after final send 429, got %d sendMessage calls", sendCount)
+	}
+}
+
 func TestTelegramChannel_SaveFile_SanitizesName(t *testing.T) {
 	ch, _ := newTestChannel(t, config.TelegramConfig{})
 	tmpDir := t.TempDir()

--- a/internal/channel/channel_test.go
+++ b/internal/channel/channel_test.go
@@ -1302,7 +1302,12 @@ func TestTelegramChannel_SendStream_FinalSendFailureKeepsIntermediateMessages(t 
 }
 
 func TestTelegramRetryAfter(t *testing.T) {
-	delay, ok := telegramRetryAfter(errors.New(`telego: editMessageText: api: 429 "Too Many Requests: retry after 717", migrate to chat ID: 0, retry after: 717`))
+	delay, ok := telegramRetryAfter(&ta.Error{ErrorCode: 429, Parameters: &ta.ResponseParameters{RetryAfter: 3}})
+	if !ok || delay != 3*time.Second {
+		t.Fatalf("api retry after = (%v, %v), want (%v, true)", delay, ok, 3*time.Second)
+	}
+
+	delay, ok = telegramRetryAfter(errors.New(`telego: editMessageText: api: 429 "Too Many Requests: retry after 717", migrate to chat ID: 0, retry after: 717`))
 	if !ok {
 		t.Fatal("expected retry after to be detected")
 	}

--- a/internal/channel/telegram.go
+++ b/internal/channel/telegram.go
@@ -50,6 +50,31 @@ type TelegramChannel struct {
 	slashCommands map[string]telegram.Command
 }
 
+func telegramRetryAfter(err error) (time.Duration, bool) {
+	if err == nil {
+		return 0, false
+	}
+	const marker = "retry after "
+	text := err.Error()
+	idx := strings.LastIndex(text, marker)
+	if idx < 0 {
+		return 0, false
+	}
+	start := idx + len(marker)
+	end := start
+	for end < len(text) && text[end] >= '0' && text[end] <= '9' {
+		end++
+	}
+	if end == start {
+		return 0, false
+	}
+	secs, convErr := strconv.Atoi(text[start:end])
+	if convErr != nil {
+		return 0, false
+	}
+	return time.Duration(secs) * time.Second, true
+}
+
 func NewTelegramChannel(cfg config.TelegramConfig, b *bus.MessageBus) (*TelegramChannel, error) {
 	if cfg.Token == "" {
 		return nil, fmt.Errorf("telegram token is required")
@@ -709,6 +734,7 @@ func (t *TelegramChannel) SendStream(ctx context.Context, chatID string, metadat
 	var contentMsg streamMsg
 	var textBuf strings.Builder
 	var streamErr string
+	var cooldownUntil time.Time
 	const (
 		statusMinGap         = 500 * time.Millisecond
 		contentMinGap        = 1 * time.Second
@@ -722,20 +748,60 @@ func (t *TelegramChannel) SendStream(ctx context.Context, chatID string, metadat
 	var pendingToolInput map[string][]byte // toolUseID -> accumulated JSON
 	var blockToolID string                 // current content_block's tool_use_id
 
+	setCooldown := func(now time.Time, err error) bool {
+		delay, ok := telegramRetryAfter(err)
+		if !ok {
+			return false
+		}
+		until := now.Add(delay)
+		if until.After(cooldownUntil) {
+			cooldownUntil = until
+		}
+		return true
+	}
+	inCooldown := func(now time.Time) bool {
+		return !cooldownUntil.IsZero() && now.Before(cooldownUntil)
+	}
+	waitCooldown := func() error {
+		if cooldownUntil.IsZero() {
+			return nil
+		}
+		delay := time.Until(cooldownUntil)
+		if delay <= 0 {
+			return nil
+		}
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return nil
+		}
+	}
+
 	upsertMessage := func(msg *streamMsg, text, parseMode string, silent bool, now time.Time) bool {
 		if text == "" {
+			return false
+		}
+		if inCooldown(now) {
+			msg.dirty = true
 			return false
 		}
 		if msg.id == 0 {
 			pid, err := t.sendPlaceholder(numChatID, text, parseMode, silent)
 			if err != nil {
+				setCooldown(now, err)
 				log.Printf("[telegram] stream placeholder failed: %v", err)
+				msg.dirty = true
 				return false
 			}
 			msg.id = pid
 		} else {
 			if err := t.editMessage(numChatID, msg.id, text, parseMode); err != nil {
+				setCooldown(now, err)
 				log.Printf("[telegram] stream edit failed: %v", err)
+				msg.dirty = true
 				return false
 			}
 		}
@@ -760,6 +826,10 @@ func (t *TelegramChannel) SendStream(ctx context.Context, chatID string, metadat
 		if !showCard {
 			return
 		}
+		if inCooldown(now) {
+			statusMsg.dirty = true
+			return
+		}
 		if !statusMsg.lastEdit.IsZero() && now.Sub(statusMsg.lastEdit) < statusMinGap {
 			statusMsg.dirty = true // deferred to ticker
 			return
@@ -769,6 +839,9 @@ func (t *TelegramChannel) SendStream(ctx context.Context, chatID string, metadat
 
 	// Ticker-driven: deferred status + content + heartbeat.
 	tickFlush := func(now time.Time) {
+		if inCooldown(now) {
+			return
+		}
 		if showCard && statusMsg.dirty && (statusMsg.lastEdit.IsZero() || now.Sub(statusMsg.lastEdit) >= statusMinGap) {
 			upsertMessage(&statusMsg, card.Render(), telego.ModeHTML, true, now)
 		}
@@ -872,8 +945,21 @@ func (t *TelegramChannel) SendStream(ctx context.Context, chatID string, metadat
 		}
 	}
 
-	if err := t.Send(bus.OutboundMessage{ChatID: chatID, Content: finalText, Metadata: metadata}); err != nil {
+	finalMsg := bus.OutboundMessage{ChatID: chatID, Content: finalText, Metadata: metadata}
+	if err := waitCooldown(); err != nil {
 		return err
+	}
+	if err := t.Send(finalMsg); err != nil {
+		if setCooldown(time.Now(), err) {
+			if err := waitCooldown(); err != nil {
+				return err
+			}
+			if err := t.Send(finalMsg); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
 
 	// Remove intermediate status/content messages only after the final report is visible.

--- a/internal/channel/telegram.go
+++ b/internal/channel/telegram.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -21,6 +22,7 @@ import (
 	"github.com/cexll/agentsdk-go/pkg/api"
 	"github.com/cexll/agentsdk-go/pkg/model"
 	"github.com/mymmrac/telego"
+	"github.com/mymmrac/telego/telegoapi"
 	tu "github.com/mymmrac/telego/telegoutil"
 	"github.com/stellarlinkco/myclaw/internal/bus"
 	"github.com/stellarlinkco/myclaw/internal/channel/telegram"
@@ -53,6 +55,12 @@ type TelegramChannel struct {
 func telegramRetryAfter(err error) (time.Duration, bool) {
 	if err == nil {
 		return 0, false
+	}
+	var apiErr *telegoapi.Error
+	if errors.As(err, &apiErr) && apiErr.Parameters != nil && apiErr.ErrorCode == http.StatusTooManyRequests {
+		if apiErr.Parameters.RetryAfter > 0 {
+			return time.Duration(apiErr.Parameters.RetryAfter) * time.Second, true
+		}
 	}
 	const marker = "retry after "
 	text := err.Error()


### PR DESCRIPTION
## Summary
- detect Telegram Bot API retry-after responses from stream placeholder, edit, and final send calls
- pause status-card and content-message updates during the cooldown instead of hammering editMessageText
- retry the final send once after the cooldown so the stream can finish cleanly

## Problem
When Telegram returned HTTP 429 with a retry-after window, myclaw kept trying to edit the streaming status/content messages. That left the status card stale, stopped visible heartbeats, and could prevent the final message from being delivered.

## Testing
- go test ./internal/channel -run ^TestTelegramRetryAfter$ -count=1
- go test ./internal/channel -run ^TestTelegramChannel_SendStream_FinalSend429RetriesOnce$ -count=1
